### PR TITLE
Allow stacked methods

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
@@ -593,6 +593,10 @@ sub get_complete_variable {
             $is_quoted = 1;
             last;
         }
+        elsif ($sibling->isa('PPI::Token::Word')
+            && $sibling->method_call()
+            # allow for stacking method calls, e.g. $foo->bar->baz->dbh->quote
+            $variable .= $sibling->content();
         else {
             last;
         }

--- a/t/ValuesAndExpressions/PreventSQLInjection.run
+++ b/t/ValuesAndExpressions/PreventSQLInjection.run
@@ -452,6 +452,12 @@ $sql = "UPDATE table_name SET field = " . $dbh->test($value) . "WHERE field = 1"
 
 $sql = "UPDATE table_name SET field = " . $dbh->test($value) . "WHERE field = " . $dbh->quote($value2);
 
+## name Allow stacked calls prior to quoting method
+## parms { quoting_methods => 'test' }
+## failures 0
+## cut
+
+$sql = "UPDATE table_name SET field = " . $foo->bar->baz->dbh->test($value) . "WHERE field = 1";
 
 ## name vars in subtest name.
 ## parms { prefer_upper_case_keywords => 0 }


### PR DESCRIPTION
I found a lot of instances of $self->dbh->quote_identifier in my code that failed to pass because multiple stacked calls were not followed. This small change should allow that to work. Only flaw is it also allows $self->quote->unsafe->thing. If that is a concern, I could further refactor the code to only test the final method call in the stack.